### PR TITLE
fix: links from gdgvit to dscvit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [IDEAS](http://ideas.gdgvitvellore.com/)
+# [IDEAS](http://ideas.dscvit.com/)
 
 A jekyll based website showcasing GDG - VIT Vellore's project ideas. Plus anyone who wants to collaborate with GDG for their project or have any idea that he wants to work on can also submit their ideas through the form given on the website.
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,17 +1,17 @@
 # Site settings
 title: GDG VIT - Project Ideas
-email: gdgvitvellore@gmail.com
+email: dscvit@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
  Google Developers Groups was established in VIT on 28th July 2014 and since then 3 successful events were conducted .
  The group now has 60 Developers ,This groups’s agenda is to introduce new technologies to the students, develop new ideas and polish skills in every possible field including management our faculty coordinator is Prof .P Senthilnathan and has guided us along this journey.
 
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://gdgvitvellore.com/" # the base hostname & protocol for your site
+url: "http://dscvit.com/" # the base hostname & protocol for your site
 twitter_username: gdgvit
 github_username:  gdgvit
 google_play: '9033840087167154769'
 google_plus_com: '101018908043689071742'  # Community link
-google_plus_per: '+gdgvitvellore'  #Personal link
+google_plus_per: '+dscvit'  #Personal link
 
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,7 +31,7 @@
     {% endif %}
 
     <li>
-      <a href="http://gdgvitvellore.com">Visit our Site</a>
+      <a href="http://dscvit.com">Visit our Site</a>
     </li>
   </ul>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,13 +19,13 @@
                     <a href="#page-top"></a>
                 </li>
                 <li>
-                    <a class="page-scroll" href="//gdgvitvellore.com/">About</a>
+                    <a class="page-scroll" href="//dscvit.com/">About</a>
                 </li>
                 <li>
-                    <a class="page-scroll" href="//blog.gdgvitvellore.com">Articles</a>
+                    <a class="page-scroll" href="//blog.dscvit.com">Articles</a>
                 </li>
                 <li>
-                    <a class="page-scroll" href="//gdgvitvellore.com/projects/">Ideas</a>
+                    <a class="page-scroll" href="//dscvit.com/projects/">Ideas</a>
                 </li>
                 <li>
                     <a class="page-scroll" href="//developers.google.com/groups/chapter/101018908043689071742/">Events</a>

--- a/about.md
+++ b/about.md
@@ -17,4 +17,4 @@ In order to maintain an all rounded community, teams of students from GDG-VIT ha
 
 You can have a look at our Inner Circle members [here](https://github.com/orgs/GDGVIT/people)
 
-Copyright © 2017 [Google Developers Group VIT VELLORE](http://www.gdgvitvellore.com)
+Copyright © 2017 [Google Developers Group VIT VELLORE](http://www.dscvit.com)

--- a/job-form.html
+++ b/job-form.html
@@ -26,9 +26,9 @@ permalink: '/job-form/'
 
         <h1>Submit an idea to GDG - VIT Organization.</h1>
         <p class="lead">Give your project proposals and let the community know about the things you are working on.</p>
-        <p class="lead"><a href="http://gdgvitvellore.com">We have a code of conduct</a>. Consider reading it before submitting project.</p>
+        <p class="lead"><a href="http://dscvit.com">We have a code of conduct</a>. Consider reading it before submitting project.</p>
         <form method="POST" action="https://api.staticman.net/v2/entry/GDGVIT/projects-ideas/gh-pages/jobs/">
-          <input name="options[redirect]" type="hidden" value="http://ideas.gdgvitvellore.com/thank-you/">
+          <input name="options[redirect]" type="hidden" value="http://ideas.dscvit.com/thank-you/">
           <input name="fields[status]" type="hidden" value="Ongoing">
           <input name="fields[date_posted]" type="hidden">
           <input name="fields[layout]" type="hidden" value="jobs">
@@ -56,7 +56,7 @@ permalink: '/job-form/'
               <input type="url"
                 class="form-control"
                 id="org_url"
-                placeholder="E.g. http://gdgvitvellore.com/"
+                placeholder="E.g. http://dscvit.com/"
                 name="fields[org_url]"
                 required>
             </div>

--- a/jobs/2017-03-10-my-vit-ios-app.md
+++ b/jobs/2017-03-10-my-vit-ios-app.md
@@ -4,7 +4,7 @@ status: Ongoing
 date_posted: '2017-03-10'
 layout: jobs
 organization: GDG - VIT Vellore
-org_url: 'http://gdgvitvellore.com'
+org_url: 'http://dscvit.com'
 title: My VIT - iOS APp
 tags: ios
 date: '2017-03-10T17:06:17.633Z'

--- a/jobs/2017-03-11-hotspot-limiter.md
+++ b/jobs/2017-03-11-hotspot-limiter.md
@@ -4,7 +4,7 @@ status: Ongoing
 date_posted: '2017-03-11'
 layout: jobs
 organization: GDG - VIT Vellore
-org_url: 'http://gdgvitvellore.com'
+org_url: 'http://dscvit.com'
 title: hotspot limiter
 tags: ''
 date: '2017-03-11T08:13:19.707Z'

--- a/jobs/2017-03-11-ios-app-for-sharepaper.md
+++ b/jobs/2017-03-11-ios-app-for-sharepaper.md
@@ -4,7 +4,7 @@ status: Ongoing
 date_posted: '2017-03-11'
 layout: jobs
 organization: GDG VIT Vellore
-org_url: 'http://gdgvitvellore.com'
+org_url: 'http://dscvit.com'
 title: iOS app for SharePaper
 tags: 'iOS,sharepaper,application'
 date: '2017-03-11T06:07:28.210Z'

--- a/jobs/2017-03-12-include-ads-from-carbonads-in-gdg-pages.md
+++ b/jobs/2017-03-12-include-ads-from-carbonads-in-gdg-pages.md
@@ -4,7 +4,7 @@ status: Ongoing
 date_posted: '2017-03-12'
 layout: jobs
 organization: Rahul Krishna @ GDG-VIT
-org_url: 'http://gdgvitvellore.com'
+org_url: 'http://dscvit.com'
 title: Include Ads from CarbonAds in GDG pages.
 tags: 'websites, advertisements'
 date: '2017-03-12T16:49:37.941Z'

--- a/jobs/2017-03-13-scrapdroid.md
+++ b/jobs/2017-03-13-scrapdroid.md
@@ -4,7 +4,7 @@ status: Ongoing
 date_posted: '2017-03-13'
 layout: jobs
 organization: RamKishore
-org_url: 'http://gdgvitvellore.com'
+org_url: 'http://dscvit.com'
 title: ScrapDroid
 tags: 'scraping,android,web-scraping,library'
 date: '2017-03-12T21:57:49.672Z'

--- a/jobs/2017-03-24-amp-pages-for-gdg-blog.md
+++ b/jobs/2017-03-24-amp-pages-for-gdg-blog.md
@@ -4,7 +4,7 @@ status: Ongoing
 date_posted: '2017-03-24'
 layout: jobs
 organization: Rishi Raj @GDGVIT
-org_url: gdgvitvellore.com
+org_url: dscvit.com
 title: AMP Pages for GDG Blog
 tags: 'blog, amp, web'
 timestamp: 1490294099

--- a/jobs/2017-04-17-.md
+++ b/jobs/2017-04-17-.md
@@ -4,7 +4,7 @@ status: Ongoing
 date_posted: '2017-04-17'
 layout: jobs
 organization: 'Piyush Goyal, Rohan Prasad'
-org_url: 'https://gdgvitvellore.com'
+org_url: 'https://dscvit.com'
 title: DeepSearch
 tags: 'web, javascript, extension'
 date: '2017-04-16T21:54:11.346Z'

--- a/staticman.yml
+++ b/staticman.yml
@@ -50,7 +50,7 @@ jobs:
   moderation: true
 
   # Name of the site. Used in notification emails.
-  name: "gdgvitvellore.com"
+  name: "dscvit.com"
 
   # Notification settings. When enabled, users can choose to receive notifications
   # via email when someone adds a reply or a new comment. This requires an account

--- a/thankyou.html
+++ b/thankyou.html
@@ -25,14 +25,14 @@ permalink: '/thank-you/'
       <div class="row col-md-6">
 
         <h1>Thanks for submitting your project proposal!</h1></br>
-        <p class="lead">Someone from the community will review your project details and publish it as soon as possible on the <a href="http://gdgvitvellore.com/projects/">project-ideas website</a>.</p>
+        <p class="lead">Someone from the community will review your project details and publish it as soon as possible on the <a href="http://dscvit.com/projects/">project-ideas website</a>.</p>
         <p>In the meantime, you can:</p>
         <ul>
-          <li><a href="http://gdgvitvellore.com/projects/">See all the current projects</a></li>
-          <li><a href="http://gdgvitvellore.com">Read more about our community.</a></li>
+          <li><a href="http://dscvit.com/projects/">See all the current projects</a></li>
+          <li><a href="http://dscvit.com">Read more about our community.</a></li>
         </ul>
         <h3>What actually happens (staticman process)</h3>
-        <p>Submitting a project propoasal sends a pull request to the <a href="https://github.com/GDGVIT/projects-ideas">GDG-VIT's projects repository</a>. Someone needs to merge the pull request. Merging triggers the publication to the GDG - VIT <a href="http://ideas.gdgvitvellore.com/">project-ideas website</a></p>
+        <p>Submitting a project propoasal sends a pull request to the <a href="https://github.com/GDGVIT/projects-ideas">GDG-VIT's projects repository</a>. Someone needs to merge the pull request. Merging triggers the publication to the GDG - VIT <a href="http://ideas.dscvit.com/">project-ideas website</a></p>
       </div>
     </div>
 


### PR DESCRIPTION
Simple replace of `gdgvitvellore` with `dscvit` for broken urls.